### PR TITLE
daemon 绑定内网地址的65512端口

### DIFF
--- a/daemon/common/common.go
+++ b/daemon/common/common.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net"
+	"strings"
+	"fmt"
 
 	"github.com/axgle/mahonia"
 	"github.com/kardianos/service"
@@ -113,4 +116,14 @@ func InArray(list []string, value string, like bool) bool {
 		}
 	}
 	return false
+}
+
+// 获取一个可以绑定的内网IP
+func BindAddr() string{
+    // 通过连接一个可达的任何一个地址，获取本地的内网的地址
+	conn, _ := net.Dial("udp", "114.114.114.114:53")
+	defer conn.Close()
+	localAddr := conn.LocalAddr().String()
+	idx := strings.LastIndex(localAddr, ":")
+	return fmt.Sprintf("%s:65512", localAddr[0:idx])
 }

--- a/daemon/task/tcp.go
+++ b/daemon/task/tcp.go
@@ -19,7 +19,7 @@ type taskServer struct {
 }
 
 func (t *taskServer) listen() (err error) {
-	t.TCPListener, err = net.Listen("tcp", common.ADDRESS)
+	t.TCPListener, err = net.Listen("tcp", common.BindAddr())
 	return err
 }
 


### PR DESCRIPTION
监听0.0.0.0 的65512端口存在安全隐患，可以被外界利用。
应该只监听内网地址的65512端口。