### PR TITLE
在WEB添加了返回外网地址的功能，修复了Agent运行在阿里云时获取的是内网IP地址的错误

### DIFF
--- a/agent/client/agent.go
+++ b/agent/client/agent.go
@@ -42,6 +42,10 @@ type Agent struct {
 	ctx          context.Context
 }
 
+type EX_IP struct {
+	IP     string              // 外部IP地址
+}
+
 var httpClient = &http.Client{
 	Timeout:   time.Second * 10,
 	Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
@@ -162,25 +166,28 @@ func (a Agent) setLocalIP(ip string) {
 
 func  (a Agent) getExternalIP()(ip string) {
 	var url string
-	var ip string
+	var response_json EX_IP
 	url = "http://" + a.ServerNetLoc + SERVER_API_IP
 	a.log("Web API:", url)
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Close = true
 	resp, err := httpClient.Do(request)
 	if err != nil {
-		return nil, err
+		a.log("Error:", err)
+		panic(1)
 	}
 	defer resp.Body.Close()
 	result, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		a.log("Error:", err)
+		panic(1)
 	}
-	err = json.Unmarshal([]byte(result), &ip)
+	err = json.Unmarshal([]byte(result), &response_json)
 	if err != nil {
-		return nil, err
+		a.log("Error:", err)
+		panic(1)
 	}
-	return ip.ip
+	return strings.Split(response_json.IP,":")[0]
 	
 }
 

--- a/agent/client/agent.go
+++ b/agent/client/agent.go
@@ -161,13 +161,27 @@ func (a Agent) setLocalIP(ip string) {
 }
 
 func  (a Agent) getExternalIP()(ip string) {
-	resp, err := http.Get("http://myip.ipip.net")
+	var url string
+	var ip string
+	url = "http://" + a.ServerNetLoc + SERVER_API_IP
+	a.log("Web API:", url)
+	request, _ := http.NewRequest("GET", url, nil)
+	request.Close = true
+	resp, err := httpClient.Do(request)
 	if err != nil {
-		return ""
+		return nil, err
 	}
 	defer resp.Body.Close()
-	content, _ := ioutil.ReadAll(resp.Body)
-	return strings.Split(strings.Split(string(content),"：")[1]," ")[0]
+	result, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(result), &ip)
+	if err != nil {
+		return nil, err
+	}
+	return ip.ip
+	
 }
 
 

--- a/agent/client/agent.go
+++ b/agent/client/agent.go
@@ -149,8 +149,36 @@ func (a Agent) setLocalIP(ip string) {
 		panic(1)
 	}
 	defer conn.Close()
-	common.LocalIP = strings.Split(conn.LocalAddr().String(), ":")[0]
+	if a.isAliYun() {
+		common.LocalIP=a.getExternalIP()
+    } else {
+        common.LocalIP = strings.Split(conn.LocalAddr().String(), ":")[0]
+    }
+	//
+	
 }
+
+func  (a Agent) getExternalIP(ip string) {
+	resp, err := http.Get("http://myip.ipip.net")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	content, _ := ioutil.ReadAll(resp.Body)
+	return strings.Split(strings.Split(content,"：")[1]," ")[0]
+}
+
+
+func  (a Agent) isAliYun(result bool) {
+	file, err := os.Open("/etc/motd")
+	if err != nil {
+		a.log("Error:", err)
+	}
+	defer file.Close()
+	data, _ := ioutil.ReadAll(file)
+	return strings.Contains(data,"Alibaba")
+}
+
 func (a *Agent) configRefresh() {
 	ticker := time.NewTicker(time.Second * time.Duration(CONFIGR_REF_INTERVAL))
 	go func() {

--- a/agent/client/agent.go
+++ b/agent/client/agent.go
@@ -142,6 +142,7 @@ func (a Agent) getServerList() ([]string, error) {
 }
 
 func (a Agent) setLocalIP(ip string) {
+	var isAliyunECS bool
 	conn, err := net.Dial("tcp", ip)
 	if err != nil {
 		a.log("Net.Dial:", ip)
@@ -149,7 +150,8 @@ func (a Agent) setLocalIP(ip string) {
 		panic(1)
 	}
 	defer conn.Close()
-	if a.isAliYun() {
+	isAliyunECS=a.isAliYun()
+	if isAliyunECS {
 		common.LocalIP=a.getExternalIP()
     } else {
         common.LocalIP = strings.Split(conn.LocalAddr().String(), ":")[0]
@@ -158,25 +160,23 @@ func (a Agent) setLocalIP(ip string) {
 	
 }
 
-func  (a Agent) getExternalIP(ip string) {
+func  (a Agent) getExternalIP()(ip string) {
 	resp, err := http.Get("http://myip.ipip.net")
 	if err != nil {
 		return ""
 	}
 	defer resp.Body.Close()
 	content, _ := ioutil.ReadAll(resp.Body)
-	return strings.Split(strings.Split(content,"：")[1]," ")[0]
+	return strings.Split(strings.Split(string(content),"：")[1]," ")[0]
 }
 
 
-func  (a Agent) isAliYun(result bool) {
-	file, err := os.Open("/etc/motd")
+func  (a Agent) isAliYun()(result bool) {
+	data, err := ioutil.ReadFile("/etc/motd")
 	if err != nil {
 		a.log("Error:", err)
 	}
-	defer file.Close()
-	data, _ := ioutil.ReadAll(file)
-	return strings.Contains(data,"Alibaba")
+	return strings.Contains(string(data),"Alibaba")
 }
 
 func (a *Agent) configRefresh() {

--- a/agent/client/config.go
+++ b/agent/client/config.go
@@ -7,5 +7,6 @@ const (
 	CONFIGR_REF_INTERVAL int             = 60
 	FAILMODE             client.FailMode = client.Failtry
 	SERVER_API           string          = "/json/serverlist"
+	SERVER_API_IP        string          ="/json/myip"
 	TESTMODE             bool            = false
 )

--- a/web/controllers/agentapi.go
+++ b/web/controllers/agentapi.go
@@ -40,6 +40,10 @@ func (c *AgentApiController) Get() {
 		c.Data["json"] = GetAliveServerList()
 	}
 
+	if strings.Contains(currentURL, "myip") {
+		c.Data["json"] = bson.M{"ip": c.Ctx.Request.RemoteAddr}
+	}
+
 	if strings.Contains(currentURL, "dbinfo") {
 		esurl := beego.AppConfig.String("elastic_search::baseurl")
 		mgourl := beego.AppConfig.String("mongodb::url")

--- a/web/routers/router.go
+++ b/web/routers/router.go
@@ -11,6 +11,7 @@ func init() {
 		beego.NSRouter("/client", &controllers.ClientController{}),
 		beego.NSRouter("/download", &controllers.DloadController{}),
 		beego.NSRouter("/serverlist", &controllers.AgentApiController{}),
+		beego.NSRouter("/myip", &controllers.AgentApiController{}),
 		beego.NSRouter("/publickey", &controllers.AgentApiController{}),
 		beego.NSRouter("/dbinfo", &controllers.AgentApiController{}),
 		beego.NSRouter("/statistics", &controllers.StatisticsController{}),


### PR DESCRIPTION
检测到Agent运行在在阿里云时，使用IPIP.NET来获取服务器的真实外网IP地址，使得命令推送功能正常进行，WEB也能正确看到上线的外网IP。